### PR TITLE
(modified patch from Jonathan Toomim) Performance fix: added methods …

### DIFF
--- a/p2pool/node.py
+++ b/p2pool/node.py
@@ -40,9 +40,7 @@ class P2PNode(p2p.Node):
             
             self.node.tracker.add(share)
         
-        new_known_txs = dict(self.node.known_txs_var.value)
-        new_known_txs.update(all_new_txs)
-        self.node.known_txs_var.set(new_known_txs)
+        self.node.known_txs_var.add(all_new_txs)
         
         if new_count:
             self.node.set_best_share()
@@ -221,7 +219,7 @@ class Node(object):
         
         # BEST SHARE
         
-        self.known_txs_var = variable.Variable({}) # hash -> tx
+        self.known_txs_var = variable.VariableDict({}) # hash -> tx
         self.mining_txs_var = variable.Variable({}) # hash -> tx
         self.get_height_rel_highest = yield height_tracker.get_height_rel_highest_func(self.bitcoind, self.factory, lambda: self.bitcoind_work.value['previous_block'], self.net)
         
@@ -236,18 +234,18 @@ class Node(object):
         @self.bitcoind_work.changed.run_and_watch
         def _(_=None):
             new_mining_txs = {}
-            new_known_txs = dict(self.known_txs_var.value)
+            added_known_txs = {}
             for tx_hash, tx in zip(self.bitcoind_work.value['transaction_hashes'], self.bitcoind_work.value['transactions']):
                 new_mining_txs[tx_hash] = tx
-                new_known_txs[tx_hash] = tx
+                added_known_txs[tx_hash] = tx
             self.mining_txs_var.set(new_mining_txs)
-            self.known_txs_var.set(new_known_txs)
+            self.known_txs_var.add(added_known_txs)
         # add p2p transactions from bitcoind to known_txs
         @self.factory.new_tx.watch
         def _(tx):
-            new_known_txs = dict(self.known_txs_var.value)
-            new_known_txs[bitcoin_data.hash256(bitcoin_data.tx_type.pack(tx))] = tx
-            self.known_txs_var.set(new_known_txs)
+            self.known_txs_var.add({
+                bitcoin_data.hash256(bitcoin_data.tx_type.pack(tx)): tx,
+            })
         # forward transactions seen to bitcoind
         @self.known_txs_var.transitioned.watch
         @defer.inlineCallbacks

--- a/p2pool/p2p.py
+++ b/p2pool/p2p.py
@@ -186,6 +186,29 @@ class Protocol(p2protocol.Protocol):
         if best_share_hash is not None:
             self.node.handle_share_hashes([best_share_hash], self)
         
+        
+        
+        def add_to_remote_view_of_my_known_txs(added):
+            if added:
+                self.send_have_tx(tx_hashes=list(added.keys()))
+        
+        
+        watch_id0 = self.node.known_txs_var.added.watch(add_to_remote_view_of_my_known_txs)
+        self.connection_lost_event.watch(lambda: self.node.known_txs_var.added.unwatch(watch_id0))
+        
+        def remove_from_remote_view_of_my_known_txs(removed):
+            if removed:
+                self.send_losing_tx(tx_hashes=list(removed.keys()))
+                
+                # cache forgotten txs here for a little while so latency of "losing_tx" packets doesn't cause problems
+                key = max(self.known_txs_cache) + 1 if self.known_txs_cache else 0
+                self.known_txs_cache[key] = removed #dict((h, before[h]) for h in removed)
+                reactor.callLater(20, self.known_txs_cache.pop, key)
+        
+        
+        watch_id1 = self.node.known_txs_var.removed.watch(remove_from_remote_view_of_my_known_txs)
+        self.connection_lost_event.watch(lambda: self.node.known_txs_var.removed.unwatch(watch_id1))
+        
         def update_remote_view_of_my_known_txs(before, after):
             added = set(after) - set(before)
             removed = set(before) - set(after)
@@ -198,8 +221,8 @@ class Protocol(p2protocol.Protocol):
                 key = max(self.known_txs_cache) + 1 if self.known_txs_cache else 0
                 self.known_txs_cache[key] = dict((h, before[h]) for h in removed)
                 reactor.callLater(20, self.known_txs_cache.pop, key)
-        watch_id = self.node.known_txs_var.transitioned.watch(update_remote_view_of_my_known_txs)
-        self.connection_lost_event.watch(lambda: self.node.known_txs_var.transitioned.unwatch(watch_id))
+        watch_id2 = self.node.known_txs_var.transitioned.watch(update_remote_view_of_my_known_txs)
+        self.connection_lost_event.watch(lambda: self.node.known_txs_var.transitioned.unwatch(watch_id2))
         
         self.send_have_tx(tx_hashes=self.node.known_txs_var.value.keys())
         
@@ -415,7 +438,7 @@ class Protocol(p2protocol.Protocol):
             
             self.remembered_txs[tx_hash] = tx
             self.remembered_txs_size += 100 + bitcoin_data.tx_type.packed_size(tx)
-        new_known_txs = dict(self.node.known_txs_var.value)
+        added_known_txs = {}
         warned = False
         for tx in txs:
             tx_hash = bitcoin_data.hash256(bitcoin_data.tx_type.pack(tx))
@@ -430,8 +453,8 @@ class Protocol(p2protocol.Protocol):
             
             self.remembered_txs[tx_hash] = tx
             self.remembered_txs_size += 100 + bitcoin_data.tx_type.packed_size(tx)
-            new_known_txs[tx_hash] = tx
-        self.node.known_txs_var.set(new_known_txs)
+            added_known_txs[tx_hash] = tx
+        self.node.known_txs_var.add(added_known_txs)
         if self.remembered_txs_size >= self.max_remembered_txs_size:
             raise PeerMisbehavingError('too much transaction data stored')
     message_forget_tx = pack.ComposedType([
@@ -609,7 +632,7 @@ class SingleClientFactory(protocol.ReconnectingClientFactory):
         self.node.lost_conn(proto, reason)
 
 class Node(object):
-    def __init__(self, best_share_hash_func, port, net, addr_store={}, connect_addrs=set(), desired_outgoing_conns=10, max_outgoing_attempts=30, max_incoming_conns=50, preferred_storage=1000, known_txs_var=variable.Variable({}), mining_txs_var=variable.Variable({}), advertise_ip=True, external_ip=None):
+    def __init__(self, best_share_hash_func, port, net, addr_store={}, connect_addrs=set(), desired_outgoing_conns=10, max_outgoing_attempts=30, max_incoming_conns=50, preferred_storage=1000, known_txs_var=variable.VariableDict({}), mining_txs_var=variable.VariableDict({}), advertise_ip=True, external_ip=None):
         self.best_share_hash_func = best_share_hash_func
         self.port = port
         self.net = net

--- a/p2pool/util/variable.py
+++ b/p2pool/util/variable.py
@@ -83,3 +83,22 @@ class Variable(object):
     
     def get_not_none(self):
         return self.get_when_satisfies(lambda val: val is not None)
+
+class VariableDict(Variable):
+    def __init__(self, value):
+        Variable.__init__(self, value)
+        self.added = Event()
+        self.removed = Event()
+    
+    def add(self, values):
+        new_items = dict([item for item in values.iteritems() if not item[0] in self.value or self.value[item[0]] != item[1]])
+        self.value.update(values)
+        self.added.happened(new_items)
+        # XXX call self.changed and self.transitioned
+    
+    def remove(self, values):
+        gone_items = dict([item for item in values.iteritems() if item[0] in self.value])
+        for key in gone_keys:
+            del self.values[key]
+        self.removed.happened(new_items)
+        # XXX call self.changed and self.transitioned


### PR DESCRIPTION
…to add or remove

transactions to known_txs_var and trigger callbacks (for caching) on just
the changes, instead of triggering a callback on the before and after
state. This should improve performance dramatically with large mempools
when receiving or removing transactions. May also improve start-up
performance. Untested as of yet.
